### PR TITLE
Add database-backed controller tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <!-- HSQLDB for tests -->
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/src/test/java/com/learning/docker/e2e/EmployeeControllerE2ETest.java
+++ b/src/test/java/com/learning/docker/e2e/EmployeeControllerE2ETest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/com/learning/docker/e2e/EmployeeControllerE2ETest.java
+++ b/src/test/java/com/learning/docker/e2e/EmployeeControllerE2ETest.java
@@ -1,0 +1,52 @@
+package com.learning.docker.e2e;
+
+import com.learning.docker.entity.Address;
+import com.learning.docker.entity.ContactInfo;
+import com.learning.docker.entity.Employee;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class EmployeeControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void createAndGetEmployeeFlow() {
+        Employee employee = new Employee();
+        employee.setFirstName("John");
+        employee.setLastName("Doe");
+        employee.setAddress(new Address("Street 1","City","12345"));
+        employee.setContactInfo(new ContactInfo("john@test.com","123"));
+        employee.setSkills(Collections.singletonList("Java"));
+
+        ResponseEntity<Employee> postResponse = restTemplate.postForEntity("http://localhost:" + port + "/api/employees", employee, Employee.class);
+        assertThat(postResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        Long id = postResponse.getBody().getId();
+
+        Employee fetched = restTemplate.getForObject("http://localhost:" + port + "/api/employees/"+id, Employee.class);
+        assertThat(fetched.getFirstName()).isEqualTo("John");
+
+        ResponseEntity<Employee[]> listResp = restTemplate.getForEntity("http://localhost:" + port + "/api/employees", Employee[].class);
+        assertThat(listResp.getBody()).hasSize(1);
+
+        restTemplate.delete("http://localhost:" + port + "/api/employees/"+id);
+        ResponseEntity<Employee[]> empty = restTemplate.getForEntity("http://localhost:" + port + "/api/employees", Employee[].class);
+        assertThat(empty.getBody()).isEmpty();
+    }
+}

--- a/src/test/java/com/learning/docker/e2e/SystemInfoControllerE2ETest.java
+++ b/src/test/java/com/learning/docker/e2e/SystemInfoControllerE2ETest.java
@@ -1,0 +1,38 @@
+package com.learning.docker.e2e;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class SystemInfoControllerE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void versionEndpointReturnsInfo() {
+        ResponseEntity<Map> response = restTemplate.getForEntity("http://localhost:" + port + "/api/v1/version", Map.class);
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).containsKeys("microservice", "version");
+    }
+
+    @Test
+    void serviceEndpointUsesTestProfile() {
+        ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + port + "/api/v1/service", String.class);
+        assertThat(response.getBody()).contains("Environment Name -");
+    }
+}

--- a/src/test/java/com/learning/docker/e2e/SystemInfoControllerE2ETest.java
+++ b/src/test/java/com/learning/docker/e2e/SystemInfoControllerE2ETest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 

--- a/src/test/java/com/learning/docker/functional/EmployeeControllerFuncTest.java
+++ b/src/test/java/com/learning/docker/functional/EmployeeControllerFuncTest.java
@@ -1,0 +1,59 @@
+package com.learning.docker.functional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learning.docker.entity.Address;
+import com.learning.docker.entity.ContactInfo;
+import com.learning.docker.entity.Employee;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class EmployeeControllerFuncTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Employee employee;
+
+    @BeforeEach
+    void setup() {
+        employee = new Employee();
+        employee.setFirstName("Jane");
+        employee.setLastName("Doe");
+        employee.setAddress(new Address("Street","City","000"));
+        employee.setContactInfo(new ContactInfo("jane@test.com","321"));
+        employee.setSkills(Collections.singletonList("Spring"));
+    }
+
+    @Test
+    void postThenFetch() throws Exception {
+        String json = objectMapper.writeValueAsString(employee);
+        String response = mockMvc.perform(post("/api/employees")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Employee created = objectMapper.readValue(response, Employee.class);
+
+        mockMvc.perform(get("/api/employees/" + created.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Jane"));
+    }
+}

--- a/src/test/java/com/learning/docker/functional/SystemInfoControllerFuncTest.java
+++ b/src/test/java/com/learning/docker/functional/SystemInfoControllerFuncTest.java
@@ -1,0 +1,26 @@
+package com.learning.docker.functional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SystemInfoControllerFuncTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void versionEndpointAccessible() throws Exception {
+        mockMvc.perform(get("/api/v1/version"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:hsqldb:mem:testdb
+spring.datasource.driverClassName=org.hsqldb.jdbcDriver
+spring.datasource.username=sa
+spring.datasource.password=
+# Generate schema automatically for tests
+spring.jpa.hibernate.ddl-auto=create-drop
+env_value=TEST


### PR DESCRIPTION
## Summary
- add HSQLDB test dependency
- use application-test properties for HSQLDB
- add E2E tests exercising controllers with real DB
- add functional tests using MockMvc

## Testing
- `mvn test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851408f4abc832fb01e7cfdf45e7729