### PR TITLE
Automate Helm chart info in README

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -27,3 +27,16 @@ jobs:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GHCR_PASSWORD }}"
+
+      - name: Update README with chart version
+        run: |
+          chart_version=$(grep '^version:' charts/Helm/Chart.yaml | awk '{print $2}')
+          sed -i -E "s/(Current Helm Chart Version: )[0-9]+\.[0-9]+\.[0-9]+/\1${chart_version}/" Readme.md
+          sed -i -E "s/(--version )[0-9]+\.[0-9]+\.[0-9]+/\1${chart_version}/" Readme.md
+          git add Readme.md
+          if git diff --cached --quiet; then
+            echo 'README is up to date'
+          else
+            git commit -m "docs: update Helm chart version to ${chart_version}"
+            git push
+          fi

--- a/Readme.md
+++ b/Readme.md
@@ -118,11 +118,27 @@ docker run -p 8005:8005 -p 5005:5005 dockerpoc-1
    kubectl apply -f K8s_Yaml/
    ```
 
+
 2. Verify deployment:
    ```bash
    kubectl get pods
    kubectl get services
    ```
+
+## 📦 Helm Chart
+
+Current Helm Chart Version: 0.2.0
+
+Add the repository:
+```bash
+helm repo add dockerpoc https://vishal210893.github.io/DockerPoc-1
+helm repo update
+```
+
+Install the chart:
+```bash
+helm install dockerpoc dockerpoc/dockerpoc-chart --version 0.2.0
+```
 
 ## 🔄 CI/CD Pipeline
 


### PR DESCRIPTION
## Summary
- document Helm chart usage in `Readme.md`
- update `helm-release.yml` workflow to patch README with the published chart version

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880f48e7b3c832fba308ad366b171f5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Helm chart usage instructions to the README and automated the README to always show the latest published chart version.

- **Automation**
  - Updated the release workflow to patch the README with the current Helm chart version after each release.

<!-- End of auto-generated description by cubic. -->

